### PR TITLE
1980 called, it wants websites built with React

### DIFF
--- a/wp-content/themes/wprig/css/1980.css
+++ b/wp-content/themes/wprig/css/1980.css
@@ -1,0 +1,1 @@
+/* silence is golden */

--- a/wp-content/themes/wprig/dev/css/1980.css
+++ b/wp-content/themes/wprig/dev/css/1980.css
@@ -1,0 +1,4 @@
+body {
+	border: 1px green solid; }
+
+/*# sourceMappingURL=../../maps/dev/css/1980.css.map */

--- a/wp-content/themes/wprig/dev/css/1980.scss
+++ b/wp-content/themes/wprig/dev/css/1980.scss
@@ -1,0 +1,1 @@
+/* silence is golden */

--- a/wp-content/themes/wprig/footer-nineteeneighty.php
+++ b/wp-content/themes/wprig/footer-nineteeneighty.php
@@ -10,6 +10,8 @@
  */
 
 ?>
+	<BR>
+	<MARQUEE>
 	<A href="<?php echo esc_url( __( 'https://wordpress.org/', 'veryserious' ) ); ?>">
 		<?php
 		/* translators: %s: CMS name, i.e. WordPress. */
@@ -21,7 +23,7 @@
 			/* translators: 1: Theme name, 2: Theme author. */
 			printf( esc_html__( 'Theme: %1$s by %2$s.', 'veryserious' ), '<a href="' . esc_url( 'https://github.com/veryserious/veryserious/' ) . '">Very Serious</a>', 'the contributors' );
 		?>
-	
+	</MARQUEE>
 <?php wp_footer(); ?>
 
 </BODY>

--- a/wp-content/themes/wprig/footer-nineteeneighty.php
+++ b/wp-content/themes/wprig/footer-nineteeneighty.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * The template for displaying the footer
+ *
+ * Contains the closing of the #content div and all content after.
+ *
+ * @link https://developer.wordpress.org/themes/basics/template-files/#template-partials
+ *
+ * @package veryserious
+ */
+
+?>
+	<A href="<?php echo esc_url( __( 'https://wordpress.org/', 'veryserious' ) ); ?>">
+		<?php
+		/* translators: %s: CMS name, i.e. WordPress. */
+		printf( esc_html__( 'Proudly powered by %s', 'veryserious' ), 'WordPress' );
+		?>
+	</A>
+	<SPAN class="sep"> | </SPAN>
+		<?php
+			/* translators: 1: Theme name, 2: Theme author. */
+			printf( esc_html__( 'Theme: %1$s by %2$s.', 'veryserious' ), '<a href="' . esc_url( 'https://github.com/veryserious/veryserious/' ) . '">Very Serious</a>', 'the contributors' );
+		?>
+	
+<?php wp_footer(); ?>
+
+</BODY>
+</HTML>

--- a/wp-content/themes/wprig/functions.php
+++ b/wp-content/themes/wprig/functions.php
@@ -385,3 +385,41 @@ require get_template_directory() . '/inc/customizer.php';
  * @link https://developers.google.com/web/fundamentals/performance/lazy-loading-guidance/images-and-video/
  */
 require get_template_directory() . '/pluggable/lazyload/lazyload.php';
+
+
+
+class DeQueueQueue {
+/**
+ * DeQueueQueue
+ *
+ * The DeQueueQueue logic allows unloading of core scripts and styles
+ * to make it easier to make HTML spec 1-4 page templates.
+ *
+ * @author     David Nuon
+ * @author     Leo Postovoit
+ * @copyright  1997-2005 The PHP Group
+ * @version    0.0.1
+ * @since      0.0.1
+ */
+
+/*
+ * This anonymous function can be called in custom headers here
+ * to unload a set of queued up scripts and styles.
+ */
+	
+	function __construct( $dscript_array, $dstyle_array ) {
+		$this->dscript_array = $dscript_array;
+		$this->dstyle_array = $dstyle_array; 
+	}
+
+	function __invoke( $name ) {
+		foreach ( $this->dscript_array as $script_item ) {
+			wp_dequeue_script ( $script_item );
+		}
+
+		foreach ( $this->dstyle_array as $style_item ) {
+			wp_dequeue_style ( $style_item );
+		}	
+	}	
+	
+}

--- a/wp-content/themes/wprig/header-kitten.php
+++ b/wp-content/themes/wprig/header-kitten.php
@@ -1,0 +1,88 @@
+<?php
+/**
+ * The header for our theme
+ *
+ * This is the template that displays all of the <head> section and everything up until <div id="content">
+ *
+ * @link https://developer.wordpress.org/themes/basics/template-files/#template-partials
+ *
+ * @package veryserious
+ */
+
+?>
+<!doctype html>
+<html <?php language_attributes(); ?> class="no-js">
+<head>
+	<meta charset="<?php bloginfo( 'charset' ); ?>">
+	<meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1">
+	<link rel="profile" href="http://gmpg.org/xfn/11">
+
+	<?php if ( ! veryserious_is_amp() ) : ?>
+		<script>document.documentElement.classList.remove("no-js");</script>
+	<?php endif; ?>
+
+	<?php wp_head(); ?>
+</head>
+
+<body <?php body_class(); ?>>
+<div id="page" class="site">
+	<a class="skip-link screen-reader-text" href="#primary"><?php esc_html_e( 'Skip to content', 'veryserious' ); ?></a>
+		<header id="masthead" class="site-header">
+			<?php if ( has_header_image() ) : ?>
+				<figure class="header-image">
+					<?php the_header_image_tag(); ?>
+				</figure>
+			<?php endif; ?>
+			<div class="site-branding">
+				<?php the_custom_logo(); ?>
+				<?php if ( is_front_page() && is_home() ) : ?>
+					<h1 class="site-title"><a href="<?php echo esc_url( home_url( '/' ) ); ?>" rel="home"><?php bloginfo( 'name' ); ?></a></h1>
+				<?php else : ?>
+					<p class="site-title"><a href="<?php echo esc_url( home_url( '/' ) ); ?>" rel="home"><?php bloginfo( 'name' ); ?></a></p>
+				<?php endif; ?>
+
+				<?php $veryserious_description = get_bloginfo( 'description', 'display' ); ?>
+				<?php if ( $veryserious_description || is_customize_preview() ) : ?>
+					<p class="site-description"><?php echo $veryserious_description; /* WPCS: xss ok. */ ?></p>
+				<?php endif; ?>
+			</div><!-- .site-branding -->
+
+			<nav id="site-navigation" class="main-navigation" aria-label="<?php esc_attr_e( 'Main menu', 'veryserious' ); ?>"
+				<?php if ( veryserious_is_amp() ) : ?>
+					[class]=" siteNavigationMenu.expanded ? 'main-navigation toggled-on' : 'main-navigation' "
+				<?php endif; ?>
+			>
+				<?php if ( veryserious_is_amp() ) : ?>
+					<amp-state id="siteNavigationMenu">
+						<script type="application/json">
+							{
+								"expanded": false
+							}
+						</script>
+					</amp-state>
+				<?php endif; ?>
+
+				<button class="menu-toggle" aria-label="<?php esc_attr_e( 'Open menu', 'veryserious' ); ?>" aria-controls="primary-menu" aria-expanded="false"
+					<?php if ( veryserious_is_amp() ) : ?>
+						on="tap:AMP.setState( { siteNavigationMenu: { expanded: ! siteNavigationMenu.expanded } } )"
+						[aria-expanded]="siteNavigationMenu.expanded ? 'true' : 'false'"
+					<?php endif; ?>
+				>
+					<?php esc_html_e( 'Menu', 'veryserious' ); ?>
+				</button>
+
+				<div class="primary-menu-container">
+					<?php
+
+					wp_nav_menu(
+						array(
+							'theme_location' => 'primary',
+							'menu_id'        => 'primary-menu',
+							'container'      => 'ul',
+						)
+					);
+
+					?>
+				</div>
+			</nav><!-- #site-navigation -->
+		</header><!-- #masthead -->

--- a/wp-content/themes/wprig/header-nineteeneighty.php
+++ b/wp-content/themes/wprig/header-nineteeneighty.php
@@ -9,21 +9,7 @@
  * @package veryserious
  */
 
-function dq_maker($dscript_array, $dstyle_array) {
-	//var_dump($dscript_array);
-	//die;
-	return function () {
-		foreach ( $dscript_array as $script_item ) {
-			wp_dequeue_script ( $script_item );
-		}
-
-		foreach ( $dstyle_array as $style_item ) {
-			wp_dequeue_style ( $style_item );
-		}		
-	};
-
-}
-
+ // here is a list of scripts to be unloaded
 $dscript_array = [
 	'admin-bar',
 	'veryserious-navigation',
@@ -33,6 +19,7 @@ $dscript_array = [
 	'wp-embed'
 ];
 
+// here is a list of scripts to be unloaded
 $dstyle_array = [
 	'veryserious-content',
 	'admin-bar',
@@ -42,9 +29,38 @@ $dstyle_array = [
 	'current-template-style'
 ];
 
+// passing the above lists to WP to unload items
+add_action( 
+		'wp_enqueue_scripts',
+		new DeQueueQueue( 
+			$dstyle_array, 
+			$dstyle_array 
+		),
+		10, 
+		1 );
+
+function EnQueueQueue()  {
 
 
-add_action( 'wp_enqueue_scripts', dq_maker($dstyle_array, $dstyle_array), 10, 1 );
+		// Add new CSS, cache busters to go!
+		/* $app = '/css/1980.css'; // Local path in theme
+			$appURI = get_stylesheet_directory_uri() . $app;
+			$appPath = get_template_directory() . $app;
+			wp_enqueue_style('app', $appURI , array(), 
+			filemtime( $appPath ) ); */
+		// Note: HTML1 spec predates CSS, so there's no need for a stylesheet.
+			
+		// Add new JS, cache busters to go!
+		/* $app = '/javascript/app.min.js'; // Local path in theme
+			$appURI = get_stylesheet_directory_uri() . $app;
+			$appPath = get_template_directory() . $app;
+		
+			wp_enqueue_script('foundation', $appURI, array(), 
+				filemtime( $appPath ), false);
+		}*/
+}
+add_action( 'wp_enqueue_scripts', 'EnQueueQueue' );
+	
 
 ?>
 <!doctype html>

--- a/wp-content/themes/wprig/header-nineteeneighty.php
+++ b/wp-content/themes/wprig/header-nineteeneighty.php
@@ -9,22 +9,42 @@
  * @package veryserious
  */
 
-function my_enqueue_stuff() {
+function dq_maker($dscript_array, $dstyle_array) {
+	//var_dump($dscript_array);
+	//die;
+	return function () {
+		foreach ( $dscript_array as $script_item ) {
+			wp_dequeue_script ( $script_item );
+		}
 
-	wp_dequeue_script ( 'admin-bar' );
-	wp_dequeue_script ( 'veryserious-navigation ' );
-	wp_dequeue_script ( 'veryserious-skip-link-focus-fix ' );
-	wp_dequeue_script ( 'comment-reply ' );
-	wp_dequeue_script ( 'veryserious-lazy-load-images ' );
+		foreach ( $dstyle_array as $style_item ) {
+			wp_dequeue_style ( $style_item );
+		}		
+	};
 
-	wp_dequeue_style ( 'veryserious-content' );
-	wp_dequeue_style ( 'admin-bar' );
-	wp_dequeue_style ( 'wp-block-library' );
-	wp_dequeue_style ( 'veryserious-fonts' );
-	wp_dequeue_style ( 'veryserious-base-style' );
-	wp_dequeue_style ( 'current-template-style' );
 }
-add_action( 'wp_enqueue_scripts', 'my_enqueue_stuff', 10 );
+
+$dscript_array = [
+	'admin-bar',
+	'veryserious-navigation',
+	'veryserious-skip-link-focus-fix',
+	'comment-reply',
+	'veryserious-lazy-load-images',
+	'wp-embed'
+];
+
+$dstyle_array = [
+	'veryserious-content',
+	'admin-bar',
+	'wp-block-library',
+	'veryserious-fonts',
+	'veryserious-base-style',
+	'current-template-style'
+];
+
+
+
+add_action( 'wp_enqueue_scripts', dq_maker($dstyle_array, $dstyle_array), 10, 1 );
 
 ?>
 <!doctype html>

--- a/wp-content/themes/wprig/header-nineteeneighty.php
+++ b/wp-content/themes/wprig/header-nineteeneighty.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * The header for our theme
+ *
+ * This is the template that displays all of the <head> section and everything up until <div id="content">
+ *
+ * @link https://developer.wordpress.org/themes/basics/template-files/#template-partials
+ *
+ * @package veryserious
+ */
+
+function my_enqueue_stuff() {
+
+	wp_dequeue_script ( 'admin-bar' );
+	wp_dequeue_script ( 'veryserious-navigation ' );
+	wp_dequeue_script ( 'veryserious-skip-link-focus-fix ' );
+	wp_dequeue_script ( 'comment-reply ' );
+	wp_dequeue_script ( 'veryserious-lazy-load-images ' );
+
+	wp_dequeue_style ( 'veryserious-content' );
+	wp_dequeue_style ( 'admin-bar' );
+	wp_dequeue_style ( 'wp-block-library' );
+	wp_dequeue_style ( 'veryserious-fonts' );
+	wp_dequeue_style ( 'veryserious-base-style' );
+	wp_dequeue_style ( 'current-template-style' );
+}
+add_action( 'wp_enqueue_scripts', 'my_enqueue_stuff', 10 );
+
+?>
+<!doctype html>
+<HTML <?php language_attributes(); ?> class="no-js">
+<HEAD>
+
+	<?php wp_head(); ?>
+</HEAD>
+<BODY <?php body_class(); ?>>
+
+<?php
+	wp_nav_menu(
+		array(
+			'theme_location' => 'primary',
+			'menu_id'        => 'primary-menu',
+			'container'      => 'ul',
+		)
+	);
+?>

--- a/wp-content/themes/wprig/index.php
+++ b/wp-content/themes/wprig/index.php
@@ -24,10 +24,10 @@
 
 $categories = get_the_category();
 
-$header_name	=	'header.php';
+$header_name	=	'header';
 $content_name	=	'content';
-$sidebar_name	=	'sidebar.php';
-$footer_name	=	'sidebar.php';
+$sidebar_name	=	'sidebar';
+$footer_name	=	'sidebar';
 
 $first_category	= 	$categories[0]->name;
 
@@ -52,7 +52,10 @@ get_header( $header_name ); ?>
 		 * This call runs only once on index and archive pages.
 		 * At some point, override functionality should be built in similar to the template part below.
 		 */
-		wp_print_styles( array( 'veryserious-content' ) ); // Note: If this was already done it will be skipped.
+		
+		if ( ! $first_category = 'nineteeneighty' ) { 
+			wp_print_styles( array( 'veryserious-content' ) ); // Note: If this was already done it will be skipped.
+		}
 
 		/* Display the appropriate header when required. */
 		veryserious_index_header();
@@ -86,8 +89,7 @@ get_header( $header_name ); ?>
 	</main><!-- #primary -->
 
 <?php
-
 if ( ! $first_category = 'nineteeneighty' ) { 
 	get_sidebar( $sidebar_name );
-	get_footer( $footer_name );
-}
+} 
+get_footer( $footer_name );

--- a/wp-content/themes/wprig/index.php
+++ b/wp-content/themes/wprig/index.php
@@ -12,6 +12,16 @@
  * @package veryserious
  */
 
+/*
+* Variables are set as Categories from WP posts.
+* modern: '2010'
+* earlyoughts: '2004'
+* twok: '2000'
+* nineteenninetyfour: '1994'
+* nineteeneighty: '1980'
+*/ 
+
+
 $categories = get_the_category();
 
 $header_name	=	'header.php';

--- a/wp-content/themes/wprig/index.php
+++ b/wp-content/themes/wprig/index.php
@@ -12,7 +12,23 @@
  * @package veryserious
  */
 
-get_header(); ?>
+$categories = get_the_category();
+
+$header_name	=	'header.php';
+$content_name	=	'content';
+$sidebar_name	=	'sidebar.php';
+$footer_name	=	'sidebar.php';
+
+if ( ! empty( $categories ) ) {
+	$first_category	= 	$categories[0]->name;
+	$header_name	= 	'header-' . $first_category . '.php';
+	$content_name 	= 	'content-' . $first_category;   
+	$sidebar_name	= 	'sidebar-' . $first_category . '.php';
+	$footer_name	= 	'footer-' . $first_category . '.php';
+}
+
+
+get_header( $header_name ); ?>
 
 	<main id="primary" class="site-main">
 
@@ -39,7 +55,9 @@ get_header(); ?>
 			 * If you want to override this in a child theme, then include a file
 			 * called content-___.php (where ___ is the Post Type name) and that will be used instead.
 			 */
-			get_template_part( 'template-parts/content', get_post_type() );
+			
+			get_template_part( 'template-parts/' . $content_name, get_post_type() );
+			
 
 		endwhile;
 
@@ -49,7 +67,7 @@ get_header(); ?>
 
 	else :
 
-		get_template_part( 'template-parts/content', 'none' );
+		get_template_part( 'template-parts/' . $content_name, 'none' );
 
 	endif;
 	?>
@@ -57,5 +75,5 @@ get_header(); ?>
 	</main><!-- #primary -->
 
 <?php
-get_sidebar();
-get_footer();
+get_sidebar( $sidebar_name );
+get_footer( $footer_name );

--- a/wp-content/themes/wprig/index.php
+++ b/wp-content/themes/wprig/index.php
@@ -29,12 +29,13 @@ $content_name	=	'content';
 $sidebar_name	=	'sidebar.php';
 $footer_name	=	'sidebar.php';
 
+$first_category	= 	$categories[0]->name;
+
 if ( ! empty( $categories ) ) {
-	$first_category	= 	$categories[0]->name;
-	$header_name	= 	'header-' . $first_category . '.php';
+	$header_name	= 	$first_category;
 	$content_name 	= 	'content-' . $first_category;   
-	$sidebar_name	= 	'sidebar-' . $first_category . '.php';
-	$footer_name	= 	'footer-' . $first_category . '.php';
+	$sidebar_name	= 	$first_category;
+	$footer_name	= 	$first_category;
 }
 
 
@@ -85,5 +86,8 @@ get_header( $header_name ); ?>
 	</main><!-- #primary -->
 
 <?php
-get_sidebar( $sidebar_name );
-get_footer( $footer_name );
+
+if ( ! $first_category = 'nineteeneighty' ) { 
+	get_sidebar( $sidebar_name );
+	get_footer( $footer_name );
+}

--- a/wp-content/themes/wprig/index.php
+++ b/wp-content/themes/wprig/index.php
@@ -40,10 +40,10 @@ if ( ! empty( $categories ) ) {
 
 
 get_header( $header_name ); ?>
-
-	<main id="primary" class="site-main">
-
-	<?php
+	<?php if ( ! $first_category = 'nineteeneighty' ) { ?>
+		<main id="primary" class="site-main">
+		?><?php
+	}
 
 	if ( have_posts() ) :
 
@@ -85,8 +85,9 @@ get_header( $header_name ); ?>
 
 	endif;
 	?>
-
-	</main><!-- #primary -->
+	<?php if ( ! $first_category = 'nineteeneighty' ) { ?>
+		</main><!-- #primary --><?php 
+	}?>
 
 <?php
 if ( ! $first_category = 'nineteeneighty' ) { 

--- a/wp-content/themes/wprig/maps/dev/css/1980.css.map
+++ b/wp-content/themes/wprig/maps/dev/css/1980.css.map
@@ -1,0 +1,1 @@
+{"version":3,"file":"../../../dev/css/1980.css","sources":["dev/css/1980.scss"],"sourcesContent":["body {\n\tborder: 1px green solid;\n}"],"names":[],"mappings":"AAAA,AAAA,IAAI,CAAC;EACJ,MAAM,EAAE,eAAe,GACvB"}

--- a/wp-content/themes/wprig/package.json
+++ b/wp-content/themes/wprig/package.json
@@ -13,7 +13,9 @@
   "bugs": {
     "url": "https://github.com/wprig/wprig/issues"
   },
-  "dependencies": {},
+  "dependencies": {
+    "@babel/register": "^7.0.0"
+  },
   "devDependencies": {
     "ajv": "^6.5.0",
     "autoprefixer": "^8.5.0",
@@ -21,7 +23,7 @@
     "babel-preset-env": "^1.7.0",
     "babel-preset-es2015": "^6.24.1",
     "babel-register": "^6.26.0",
-    "browser-sync": "^2.24.7",
+    "browser-sync": "^2.26.3",
     "eslint": "^4.18.1",
     "eslint-config-gulp": "^3.0.1",
     "eslint-config-standard": "^11.0.0",

--- a/wp-content/themes/wprig/sidebar-nineteeneighty.php
+++ b/wp-content/themes/wprig/sidebar-nineteeneighty.php
@@ -1,17 +1,1 @@
-<?php
-/**
- * The sidebar containing the main widget area
- *
- * @link https://developer.wordpress.org/themes/basics/template-files/#template-partials
- *
- * @package veryserious
- */
-
-if ( ! is_active_sidebar( 'sidebar-1' ) ) {
-	return;
-}
-?>
-<?php wp_print_styles( array( 'veryserious-sidebar', 'veryserious-widgets' ) ); ?>
-<aside id="secondary" class="primary-sidebar widget-area">
-	<?php dynamic_sidebar( 'sidebar-1' ); ?>
-</aside><!-- #secondary -->
+<?php /* silence is golden, so are dank memes */ ?>

--- a/wp-content/themes/wprig/sidebar-nineteeneighty.php
+++ b/wp-content/themes/wprig/sidebar-nineteeneighty.php
@@ -1,0 +1,17 @@
+<?php
+/**
+ * The sidebar containing the main widget area
+ *
+ * @link https://developer.wordpress.org/themes/basics/template-files/#template-partials
+ *
+ * @package veryserious
+ */
+
+if ( ! is_active_sidebar( 'sidebar-1' ) ) {
+	return;
+}
+?>
+<?php wp_print_styles( array( 'veryserious-sidebar', 'veryserious-widgets' ) ); ?>
+<aside id="secondary" class="primary-sidebar widget-area">
+	<?php dynamic_sidebar( 'sidebar-1' ); ?>
+</aside><!-- #secondary -->

--- a/wp-content/themes/wprig/template-parts/content-kitten.php
+++ b/wp-content/themes/wprig/template-parts/content-kitten.php
@@ -1,0 +1,85 @@
+<?php
+/**
+ * Template part for displaying posts
+ *
+ * @link https://codex.wordpress.org/Template_Hierarchy
+ *
+ * @package veryserious
+ */
+
+?>
+<h1>kittens for david</h1>
+<article id="post-<?php the_ID(); ?>" <?php post_class(); ?>>
+	<header class="entry-header">
+		<?php
+		if ( is_singular() ) :
+			the_title( '<h1 class="entry-title">', '</h1>' );
+		else :
+			the_title( '<h2 class="entry-title"><a href="' . esc_url( get_permalink() ) . '" rel="bookmark">', '</a></h2>' );
+		endif;
+
+		if ( 'post' === get_post_type() ) :
+			?>
+			<div class="entry-meta">
+				<?php
+					veryserious_posted_on();
+					veryserious_posted_by();
+					veryserious_comments_link();
+				?>
+			</div><!-- .entry-meta -->
+			<?php
+		endif;
+		?>
+	</header><!-- .entry-header -->
+
+	<?php veryserious_post_thumbnail(); ?>
+
+	<div class="entry-content">
+		<?php
+		the_content(
+			sprintf(
+				wp_kses(
+					/* translators: %s: Name of current post. Only visible to screen readers */
+					__( 'Continue reading<span class="screen-reader-text"> "%s"</span>', 'veryserious' ),
+					array(
+						'span' => array(
+							'class' => array(),
+						),
+					)
+				),
+				get_the_title()
+			)
+		);
+
+		wp_link_pages(
+			array(
+				'before' => '<div class="page-links">' . esc_html__( 'Pages:', 'veryserious' ),
+				'after'  => '</div>',
+			)
+		);
+		?>
+	</div><!-- .entry-content -->
+
+	<footer class="entry-footer">
+		<?php
+		veryserious_post_categories();
+		veryserious_post_tags();
+		veryserious_edit_post_link();
+		?>
+	</footer><!-- .entry-footer -->
+</article><!-- #post-<?php the_ID(); ?> -->
+
+<?php
+if ( is_singular() ) :
+	the_post_navigation(
+		array(
+			'prev_text' => '<div class="post-navigation-sub"><span>' . esc_html__( 'Previous:', 'veryserious' ) . '</span></div>%title',
+			'next_text' => '<div class="post-navigation-sub"><span>' . esc_html__( 'Next:', 'veryserious' ) . '</span></div>%title',
+		)
+	);
+
+	// If comments are open or we have at least one comment, load up the comment template.
+	if ( comments_open() || get_comments_number() ) :
+		comments_template();
+	endif;
+endif;

--- a/wp-content/themes/wprig/template-parts/content-nineteeneighty.php
+++ b/wp-content/themes/wprig/template-parts/content-nineteeneighty.php
@@ -1,0 +1,74 @@
+<?php
+/**
+ * Template part for displaying posts
+ *
+ * @link https://codex.wordpress.org/Template_Hierarchy
+ *
+ * @package veryserious
+ */
+
+?>
+<H2>article id="post-<?php the_ID(); ?>" <?php post_class(); ?></H2>
+
+		<?php
+		if ( is_singular() ) :
+			the_title( '<h1 class="entry-title">', '</h1>' );
+		else :
+			the_title( '<h2 class="entry-title"><a href="' . esc_url( get_permalink() ) . '" rel="bookmark">', '</a></h2>' );
+		endif;
+
+		if ( 'post' === get_post_type() ) :
+			?>
+			
+			<?php
+				veryserious_posted_on();
+				veryserious_posted_by();
+				veryserious_comments_link();
+			?>
+		
+			<?php
+		endif;
+		?>
+		<?php
+		the_content(
+			sprintf(
+				wp_kses(
+					/* translators: %s: Name of current post. Only visible to screen readers */
+					__( 'Continue reading<span class="screen-reader-text"> "%s"</span>', 'veryserious' ),
+					array(
+						'span' => array(
+							'class' => array(),
+						),
+					)
+				),
+				get_the_title()
+			)
+		);
+
+		wp_link_pages(
+			array(
+				'before' => '<div class="page-links">' . esc_html__( 'Pages:', 'veryserious' ),
+				'after'  => '</div>',
+			)
+		);
+		?>
+		<?php
+		veryserious_post_categories();
+		veryserious_post_tags();
+		veryserious_edit_post_link();
+		?>
+
+<?php
+if ( is_singular() ) :
+	the_post_navigation(
+		array(
+			'prev_text' => '<div class="post-navigation-sub"><span>' . esc_html__( 'Previous:', 'veryserious' ) . '</span></div>%title',
+			'next_text' => '<div class="post-navigation-sub"><span>' . esc_html__( 'Next:', 'veryserious' ) . '</span></div>%title',
+		)
+	);
+
+	// If comments are open or we have at least one comment, load up the comment template.
+	// if ( comments_open() || get_comments_number() ) :
+	//	comments_template();
+	// endif;
+endif;

--- a/wp-content/themes/wprig/template-parts/content-nineteeneighty.php
+++ b/wp-content/themes/wprig/template-parts/content-nineteeneighty.php
@@ -8,7 +8,6 @@
  */
 
 ?>
-<H2>article id="post-<?php the_ID(); ?>" <?php post_class(); ?></H2>
 
 		<?php
 		if ( is_singular() ) :
@@ -48,50 +47,31 @@
 				)
 		);
 
-
-		// strip classes
-		$pattern = '/(<[^>]+) class=".*?"/i';
-		$htmlcontent_1 = 
-			preg_replace(
-				$pattern ,
-				'$1' , 
-				$htmlcontent
-			);
-
-
-		// strip inline styles
-		$pattern = '/(<[^>]+) style=".*?"/i';
-		$htmlcontent_2 = 
-			preg_replace(
-				$pattern ,
-				'$1' , 
-				$htmlcontent_1
-			);
-
-
 		// strip everything BUT the tags here
-		$htmlcontent_3 = 
+		$htmlcontent_0 = 
 			strip_tags( 
-				$htmlcontent_2 , 
-				'<p><br><li><ul><ol><a>' 
+				$htmlcontent , 
+				'<p><br><li><ul><ol><a><h2><h3><h4><h5><h6><i><b><u><em><strong><span>' 
 			);
 
+		$pattern_array = array(
+			array( /* classes */ '/(<[^>]+) class=".*?"/i', '$1' ),
+			array( /* styles */ '/(<[^>]+) style=".*?"/i', '$1' ),
+			array( /* god mode 1 */ '/<([^<\/>]*)>([\s]*?|(?R))<\/\1>/imsU', '' ),
+			array( /* god mode 2 */ '/<([^<\/>]*)>([\s]*?|(?R))<\/\1>/imsU', '' )
+		);
 
-		// disregard tags, acquire acetone for stripping things down
-		// props https://websupporter.net/blog/an-example-of-how-to-remove-empty-html-tags-with-php/
-		$pattern = '/<([^<\/>]*)>([\s]*?|(?R))<\/\1>/imsU';
-		$htmlcontent_final = 
-			preg_replace(
-				$pattern ,
-				'' , 
-					preg_replace(
-						$pattern ,
-						'' , 
-						$htmlcontent_3
-					)
-				);
+		foreach ( $pattern_array as $pattern ) {
+			$htmlcontent_0 = preg_replace( $pattern[0] , $pattern[1], $htmlcontent_0 );
+		}
 		
+		$htmlcontent_final = $htmlcontent_0 . 
+		'<I>This is article <u>post-' . get_the_ID() . '</u>, written with love :-)</I><BR><BR>';
+
 		echo $htmlcontent_final;
+
+		// echo 'dank memes never die'; 
+		// die();
 
 		wp_link_pages(
 			array(

--- a/wp-content/themes/wprig/template-parts/content-nineteeneighty.php
+++ b/wp-content/themes/wprig/template-parts/content-nineteeneighty.php
@@ -30,45 +30,94 @@
 		endif;
 		?>
 		<?php
-		the_content(
-			sprintf(
-				wp_kses(
-					/* translators: %s: Name of current post. Only visible to screen readers */
-					__( 'Continue reading<span class="screen-reader-text"> "%s"</span>', 'veryserious' ),
-					array(
-						'span' => array(
-							'class' => array(),
-						),
-					)
-				),
-				get_the_title()
-			)
+
+		$htmlcontent = get_the_content(
+				sprintf(
+					wp_kses(
+						/* translators: %s: Name of current post. 
+						Only visible to screen readers */
+						__( 'Continue reading<span class="screen-reader-text"> "%s"</span>', 
+							'veryserious' ),
+						array(
+							'span' => array(
+								'class' => array(),
+							),
+						)
+					),
+					get_the_title()
+				)
 		);
+
+
+		// strip classes
+		$pattern = '/(<[^>]+) class=".*?"/i';
+		$htmlcontent_1 = 
+			preg_replace(
+				$pattern ,
+				'$1' , 
+				$htmlcontent
+			);
+
+
+		// strip inline styles
+		$pattern = '/(<[^>]+) style=".*?"/i';
+		$htmlcontent_2 = 
+			preg_replace(
+				$pattern ,
+				'$1' , 
+				$htmlcontent_1
+			);
+
+
+		// strip everything BUT the tags here
+		$htmlcontent_3 = 
+			strip_tags( 
+				$htmlcontent_2 , 
+				'<p><br><li><ul><ol><a>' 
+			);
+
+
+		// disregard tags, acquire acetone for stripping things down
+		// props https://websupporter.net/blog/an-example-of-how-to-remove-empty-html-tags-with-php/
+		$pattern = '/<([^<\/>]*)>([\s]*?|(?R))<\/\1>/imsU';
+		$htmlcontent_final = 
+			preg_replace(
+				$pattern ,
+				'' , 
+					preg_replace(
+						$pattern ,
+						'' , 
+						$htmlcontent_3
+					)
+				);
+		
+		echo $htmlcontent_final;
 
 		wp_link_pages(
 			array(
-				'before' => '<div class="page-links">' . esc_html__( 'Pages:', 'veryserious' ),
+				'before' => '<div class="page-links">' . 
+				esc_html__( 'Pages:', 'veryserious' ),
 				'after'  => '</div>',
 			)
 		);
-		?>
-		<?php
-		veryserious_post_categories();
-		veryserious_post_tags();
-		veryserious_edit_post_link();
-		?>
+?>
+<?php
+	veryserious_post_categories();
+	veryserious_post_tags();
+	veryserious_edit_post_link();
+?>
 
 <?php
-if ( is_singular() ) :
-	the_post_navigation(
-		array(
-			'prev_text' => '<div class="post-navigation-sub"><span>' . esc_html__( 'Previous:', 'veryserious' ) . '</span></div>%title',
-			'next_text' => '<div class="post-navigation-sub"><span>' . esc_html__( 'Next:', 'veryserious' ) . '</span></div>%title',
-		)
-	);
+	if ( is_singular() ) :
+		the_post_navigation(
+			array(
+				'prev_text' => '<div class="post-navigation-sub"><span>' . esc_html__( 'Previous:', 'veryserious' ) . '</span></div>%title',
+				'next_text' => '<div class="post-navigation-sub"><span>' . esc_html__( 'Next:', 'veryserious' ) . '</span></div>%title',
+			)
+		);
 
-	// If comments are open or we have at least one comment, load up the comment template.
-	// if ( comments_open() || get_comments_number() ) :
-	//	comments_template();
-	// endif;
-endif;
+		// If comments are open or we have at least one comment, load up the comment template.
+		// if ( comments_open() || get_comments_number() ) :
+		//	comments_template();
+		// endif;
+	endif;

--- a/wp-content/themes/wprig/template-parts/content-nineteeneighty.php
+++ b/wp-content/themes/wprig/template-parts/content-nineteeneighty.php
@@ -52,21 +52,35 @@
 			strip_tags( 
 				$htmlcontent , 
 				'<p><br><li><ul><ol><a><h2><h3><h4><h5><h6><i><b><u><em><strong><span>' 
-			);
+			);	
 
 		$pattern_array = array(
 			array( /* classes */ '/(<[^>]+) class=".*?"/i', '$1' ),
 			array( /* styles */ '/(<[^>]+) style=".*?"/i', '$1' ),
 			array( /* god mode 1 */ '/<([^<\/>]*)>([\s]*?|(?R))<\/\1>/imsU', '' ),
-			array( /* god mode 2 */ '/<([^<\/>]*)>([\s]*?|(?R))<\/\1>/imsU', '' )
+			array( /* god mode 2 */ '/<([^<\/>]*)>([\s]*?|(?R))<\/\1>/imsU', '' ),
 		);
-
 		foreach ( $pattern_array as $pattern ) {
 			$htmlcontent_0 = preg_replace( $pattern[0] , $pattern[1], $htmlcontent_0 );
 		}
 		
-		$htmlcontent_final = $htmlcontent_0 . 
-		'<I>This is article <u>post-' . get_the_ID() . '</u>, written with love :-)</I><BR><BR>';
+		// convert all lower case tags to upper case
+		// todo: Convert this to a regex
+		$htmlcontent_1 = preg_replace_callback(
+				"/(<\/?\w+)(.*?>)/", 
+					function ($m) {
+						  return strtoupper($m[1]) .
+						  $m[2]; 
+						}, 
+					$htmlcontent_0 
+					); 
+
+		// our love <3
+		$htmlcontent_final = 
+			$htmlcontent_1 . 
+			'<I>This is article <U>post-' . 
+			get_the_ID() . 
+			'</U>, written with love :-)</I><BR><BR>';
 
 		echo $htmlcontent_final;
 
@@ -75,9 +89,9 @@
 
 		wp_link_pages(
 			array(
-				'before' => '<div class="page-links">' . 
+				//'before' => '<div class="page-links">' . 
 				esc_html__( 'Pages:', 'veryserious' ),
-				'after'  => '</div>',
+				//'after'  => '</div>',
 			)
 		);
 ?>

--- a/wp-content/themes/wprig/verbose/css/1980.css
+++ b/wp-content/themes/wprig/verbose/css/1980.css
@@ -1,0 +1,1 @@
+/* silence is golden */


### PR DESCRIPTION
This proposal brings initial support to WordPress to support templates for text-only browsers.

We created the appropriate templating language following the `WordPress` way (there is no way to call sub-templates without rewriting core functions) and this lays the prototype for where and how these templates would exist.

We also dequeued the scripts and styles required to make the theme be a theme by first running [this function ](https://gist.github.com/postphotos/eb439a40331e4b4d021f6e55ac74a56a) and then using that array in `/header-nineteeneighty.php` to dequeue everything. _(Get outta line, pal!)_

After discovering that illegal HTML (OK by modern standards but not by old standards) is available, we stripped semantic HTML elements, classes and styles: This PR lays down the fundamental foundation for what tag stripping will look like (leveraging `preg_replace` quite heavily.) 

The next four templates will be less extreme versions of what's going on here, or the same level of stripping and re-building by enqueueing NEW stylesheets and JS as needed.


Please review as a sanity check and for general code quality.